### PR TITLE
nightly builds

### DIFF
--- a/source/developer-guide/nightly-builds/create.rst
+++ b/source/developer-guide/nightly-builds/create.rst
@@ -30,20 +30,26 @@ This is an example for the package kolab-syncroton:
 
 Furthermore you need to modify the build files to reference the new tar.gz file, and to find the extracted code in the right place.
 
-For CentOS, those changes are required in the .spec file:
+For **CentOS**, those changes are required in the .spec file:
 
 .. parsed-literal::
 
     -Source0:        http://mirror.kolabsys.com/pub/releases/%{name}-%{version}.tar.gz
     +Source0:        %{name}-master.tar.gz
     -%setup -q -n %{name}-%{version}
-    +%setup -q -n %{name}-master    
+    +%setup -q -n %{name}-master 
+
+For **Debian**, you need to change the .dsc file:
+
+.. parsed-literal::
+    - 00000000000000000000000000000000 0 kolab-syncroton-2.2.2.tar.gz
+    + 00000000000000000000000000000000 0 kolab-syncroton-git-master.tar.gz
 
 Adjust the release numbers
 --------------------------
 One other issue: in order for the :ref:`installation of the nightly packages <dev-packaging-install_nightly>` to work properly, you need to adjust the release number of the packages.
 
-For CentOS, you need to add the following line to the top of your .spec file:
+For **CentOS**, you need to add the following line to the top of your .spec file:
 
 .. parsed-literal::
     %define release_prefix dev%(date +%%Y%%m%%d)
@@ -54,6 +60,22 @@ And in the settings of your project, go to "Advanced" / "Project Config", and en
     Release: 99.%%{?release_prefix}.<CI_CNT>.<B_CNT>
 
 For more details, see http://en.opensuse.org/openSUSE:Build_Service_prjconf
+
+For **Debian**, you need to change the .dsc file:
+
+.. parsed-literal::
+    -Version: 2.2.2-0~kolab1
+    +Version: 2.2.2-0~kolab1-dev20131023
+
+And also the debian.changelog file:
+
+.. parsed-literal::
+    +kolab-syncroton (2.2.2-0~kolab1-dev20131023) unstable; urgency=low
+    +  * nightly build
+    + -- Timotheus Pokorra (TBits.net) <tp@tbits.net>  Wed, 23 Oct 2013 15:13:40 +0200
+    +
+
+.. note:: for Debian, the debian.changelog and the .dsc file need to be updated each time when a new release should be built! See below for the script that does the nightly builds.
 
 Commit the changes
 ------------------

--- a/source/developer-guide/nightly-builds/install.rst
+++ b/source/developer-guide/nightly-builds/install.rst
@@ -38,3 +38,42 @@ Now run:
     yum install kolab
     setup-kolab
 
+Debian 7.0
+==========
+
+See also the usual steps, that you do for installing Kolab3 (see also :ref:`installation-debian`). We are adding another repository for the nightly built packages.
+
+.. parsed-literal::
+    cat > /etc/apt/sources.list.d/kolab.list <<FINISH
+    deb http://obs.kolabsys.com:82/Kolab:/3.1/Debian_7.0/ ./
+    deb http://obs.kolabsys.com:82/Kolab:/3.1:/Updates/Debian_7.0/ ./
+    deb http://obs.kolabsys.com:82/home:/tpokorra:/branches:/Kolab:/Development/Debian_7.0/ ./
+    FINISH
+    
+    wget http://obs.kolabsys.com:82/Kolab:/3.1/Debian_7.0/Release.key
+    apt-key add Release.key; rm -rf Release.key
+    wget http://obs.kolabsys.com:82/Kolab:/3.1:/Updates/Debian_7.0/Release.key
+    apt-key add Release.key; rm -rf Release.key
+    wget http://obs.kolabsys.com:82/home:/tpokorra:/branches:/Kolab:/Development/Debian_7.0/Release.key
+    apt-key add Release.key; rm -rf Release.key
+    
+    cat > /etc/apt/preferences.d/kolab <<FINISH
+    Package: *
+    Pin: origin obs.kolabsys.com
+    Pin-Priority: 501
+    FINISH
+    
+    apt-get update
+    apt-get install kolab
+
+Since there is a `problem during setup-kolab <https://issues.kolab.org/show_bug.cgi?id=2404>`_, at the moment you should run these commands as well:
+
+.. parsed-literal::
+    touch /etc/postfix/header_checks.inbound
+    touch /etc/postfix/header_checks.submission
+    touch /etc/postfix/header_checks.internal
+
+And then run
+
+.. parsed-literal::
+    setup-kolab

--- a/source/developer-guide/nightly-builds/install.rst
+++ b/source/developer-guide/nightly-builds/install.rst
@@ -44,17 +44,18 @@ Debian 7.0
 See also the usual steps, that you do for installing Kolab3 (see also :ref:`installation-debian`). We are adding another repository for the nightly built packages.
 
 .. parsed-literal::
+    username=tpokorra
     cat > /etc/apt/sources.list.d/kolab.list <<FINISH
     deb http://obs.kolabsys.com:82/Kolab:/3.1/Debian_7.0/ ./
     deb http://obs.kolabsys.com:82/Kolab:/3.1:/Updates/Debian_7.0/ ./
-    deb http://obs.kolabsys.com:82/home:/tpokorra:/branches:/Kolab:/Development/Debian_7.0/ ./
+    deb http://obs.kolabsys.com:82/home:/$username:/branches:/Kolab:/Development/Debian_7.0/ ./
     FINISH
     
     wget http://obs.kolabsys.com:82/Kolab:/3.1/Debian_7.0/Release.key
     apt-key add Release.key; rm -rf Release.key
     wget http://obs.kolabsys.com:82/Kolab:/3.1:/Updates/Debian_7.0/Release.key
     apt-key add Release.key; rm -rf Release.key
-    wget http://obs.kolabsys.com:82/home:/tpokorra:/branches:/Kolab:/Development/Debian_7.0/Release.key
+    wget http://obs.kolabsys.com:82/home:/$username:/branches:/Kolab:/Development/Debian_7.0/Release.key
     apt-key add Release.key; rm -rf Release.key
     
     cat > /etc/apt/preferences.d/kolab <<FINISH
@@ -65,13 +66,6 @@ See also the usual steps, that you do for installing Kolab3 (see also :ref:`inst
     
     apt-get update
     apt-get install kolab
-
-Since there is a `problem during setup-kolab <https://issues.kolab.org/show_bug.cgi?id=2404>`_, at the moment you should run these commands as well:
-
-.. parsed-literal::
-    touch /etc/postfix/header_checks.inbound
-    touch /etc/postfix/header_checks.submission
-    touch /etc/postfix/header_checks.internal
 
 And then run
 

--- a/source/developer-guide/nightly-builds/install.rst
+++ b/source/developer-guide/nightly-builds/install.rst
@@ -13,22 +13,23 @@ It is recommended to do a fresh install of the machine, when you want to go back
 CentOS 6
 =================================================
 
-First the usual steps, that you do for installing Kolab3 (see also the Kolab Community Installation Guide):
+First the usual steps, that you do for installing Kolab3 (see also :ref:`installation-centos`):
 
 .. parsed-literal::
 
     wget http://ftp.uni-kl.de/pub/linux/fedora-epel/6/i386/epel-release-6-8.noarch.rpm
     yum -y localinstall --nogpgcheck epel-release-6-8.noarch.rpm
-    wget http://mirror.kolabsys.com/pub/redhat/kolab-3.1/el6/development/x86_64/kolab-3.1-community-release-6-2.el6.kolab_3.1.noarch.rpm
-    wget http://mirror.kolabsys.com/pub/redhat/kolab-3.1/el6/development/x86_64/kolab-3.1-community-release-development-6-2.el6.kolab_3.1.noarch.rpm
-    yum -y localinstall kolab-3*.rpm
+    cd /etc/yum.repos.d/
+    wget http://obs.kolabsys.com:82/Kolab:/3.1/CentOS_6/Kolab:3.1.repo
+    wget http://obs.kolabsys.com:82/Kolab:/3.1:/Updates/CentOS_6/Kolab:3.1:Updates.repo
+    cd -
 
 Now also install the repo for the `obs.kolabsys.com tpokorra Project <https://obs.kolabsys.com/project/show?project=home%3Atpokorra%3Abranches%3AKolab%3ADevelopment>`_:
 
 .. parsed-literal::
 
     wget http://obs.kolabsys.com:82/home:/tpokorra:/branches:/Kolab:/Development/CentOS_6/home:tpokorra:branches:Kolab:Development.repo \\
-              -O /etc/yum.repos.d/obs-tpokorra-nightly-kolab.repo --no-check-certificate
+              -O /etc/yum.repos.d/obs-tpokorra-nightly-kolab.repo
 
 Now run:
 

--- a/source/installation-guide/centos.rst
+++ b/source/installation-guide/centos.rst
@@ -1,3 +1,5 @@
+.. _installation-centos:
+
 ======================
 Installation on CentOS
 ======================

--- a/source/installation-guide/debian.rst
+++ b/source/installation-guide/debian.rst
@@ -1,3 +1,5 @@
+.. _installation-debian:
+
 ======================
 Installation on Debian
 ======================


### PR DESCRIPTION
install from OBS, not from mirror.kolabsys.com; 
and now for Debian as well, similar to CentOS nightly builds
