### PR TITLE
Bug 2505 - openSUSE 12.3 Documentation error

### DIFF
--- a/source/installation-guide/opensuse.rst
+++ b/source/installation-guide/opensuse.rst
@@ -8,22 +8,22 @@ Installation on openSUSE
     
         .. parsed-literal::
 
-            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2/openSUSE_13.1/`
-            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2:/Updates/openSUSE_13.1/`
+            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2/openSUSE_13.1/Kolab:3.2.repo`
+            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2:/Updates/openSUSE_13.1/Kolab:3.2:Updates.repo`
             
     *   For openSUSE 12.3:
     
         .. parsed-literal::
 
-            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2/openSUSE_12.3/`
-            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2:/Updates/openSUSE_12.3/`
+            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2/openSUSE_12.3/Kolab:3.2.repo`
+            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2:/Updates/openSUSE_12.3/Kolab:3.2:Updates.repo`
             
     *   For openSUSE 12.2:
     
         .. parsed-literal::
 
-            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2/openSUSE_12.2/`
-            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2:/Updates/openSUSE_12.2/`
+            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2/openSUSE_12.2/Kolab:3.2.repo`
+            # :command:`zypper ar http://obs.kolabsys.com:82/Kolab:/3.2:/Updates/openSUSE_12.2/Kolab:3.2:Updates.repo`
             
 2.  Install Kolab Groupware:
 


### PR DESCRIPTION
zypper expects either a .repo file or a repository dir + an alias for the repo.
