### PR TITLE
Several improvements in the SSL howto

### DIFF
--- a/source/howtos/secure-kolab-server.rst
+++ b/source/howtos/secure-kolab-server.rst
@@ -342,6 +342,13 @@ Set correct SSL parameters for HTTP_Request2. This will ensure the
 
         # :command:`sed -i -e '/kolab_ssl/d' /etc/roundcubemail/libkolab.inc.php`
 
+
+#.  Change freebusy API url in the ``libkolab`` plugin configuration:
+
+    .. parsed-literal::
+
+        # :command:`sed -i -e 's/http:/https:/' /etc/roundcubemail/libkolab.inc.php`
+
 #.  Change Chwala API url in the ``kolab_files`` plugin configuration:
 
     .. parsed-literal::

--- a/source/howtos/secure-kolab-server.rst
+++ b/source/howtos/secure-kolab-server.rst
@@ -384,3 +384,11 @@ Set correct SSL parameters for HTTP_Request2. This will ensure the
         \\$config['kolab_addressbook_carddav_url']   = 'https://%h/iRony/addressbooks/%u/%i';
         EOF`
 
+#.  Additionaly, you can redirect all http traffic to https:
+
+    .. parsed-literal::
+
+        # :command:`cat >> /etc/roundcubemail/config.inc.php << EOF
+        # Force https redirect for http requests
+        \\$config['force_https'] = true;
+        EOF`

--- a/source/howtos/secure-kolab-server.rst
+++ b/source/howtos/secure-kolab-server.rst
@@ -373,7 +373,7 @@ Set correct SSL parameters for HTTP_Request2. This will ensure the
 
         # :command:`cat >> /etc/roundcubemail/config.inc.php << EOF
         # caldav/webdav
-        \\$config['calendar_caldav_url']             = "https://kolab.example.org/iRony/calendars/%u/%i";
-        \\$config['kolab_addressbook_carddav_url']   = 'https://kolab.example.org/iRony/addressbooks/%u/%i';
+        \\$config['calendar_caldav_url']             = "https://%h/iRony/calendars/%u/%i";
+        \\$config['kolab_addressbook_carddav_url']   = 'https://%h/iRony/addressbooks/%u/%i';
         EOF`
 


### PR DESCRIPTION
- change iRony URLs to automatically use roundcube's hostname
- add freebusy api url change
- enable force-https in roundcube
